### PR TITLE
[Misc] Add unit tests for discussions module to increase test coverage

### DIFF
--- a/application-changerequest-discussions/pom.xml
+++ b/application-changerequest-discussions/pom.xml
@@ -33,7 +33,7 @@
   <packaging>jar</packaging>
   <properties>
     <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
-    <xwiki.jacoco.instructionRatio>0.74</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.83</xwiki.jacoco.instructionRatio>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
   </properties>
   <dependencies>

--- a/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/ChangeRequestDiscussionDiffBlockTest.java
+++ b/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/ChangeRequestDiscussionDiffBlockTest.java
@@ -1,0 +1,73 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.changerequest.discussions;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.contrib.changerequest.discussions.references.ChangeRequestLineDiffReference;
+import org.xwiki.diff.display.UnifiedDiffBlock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link ChangeRequestDiscussionDiffBlock}.
+ *
+ * @version $Id$
+ */
+class ChangeRequestDiscussionDiffBlockTest
+{
+    @Test
+    void getters()
+    {
+        UnifiedDiffBlock<String, Character> diffBlock = new UnifiedDiffBlock<>();
+        ChangeRequestLineDiffReference reference = mock(ChangeRequestLineDiffReference.class);
+        ChangeRequestDiscussionDiffBlock block = new ChangeRequestDiscussionDiffBlock(diffBlock, reference);
+
+        assertEquals(diffBlock, block.getDiffBlock());
+        assertEquals(reference, block.getReference());
+    }
+
+    @Test
+    void equalsAndHashCode()
+    {
+        UnifiedDiffBlock<String, Character> diffBlock = new UnifiedDiffBlock<>();
+        ChangeRequestLineDiffReference reference = mock(ChangeRequestLineDiffReference.class);
+        ChangeRequestDiscussionDiffBlock block = new ChangeRequestDiscussionDiffBlock(diffBlock, reference);
+
+        assertEquals(block, block);
+        assertNotEquals(block, null);
+        assertNotEquals(block, "somethingelse");
+
+        ChangeRequestDiscussionDiffBlock sameFields = new ChangeRequestDiscussionDiffBlock(diffBlock, reference);
+        assertEquals(block, sameFields);
+        assertEquals(block.hashCode(), sameFields.hashCode());
+
+        ChangeRequestDiscussionDiffBlock otherReference =
+            new ChangeRequestDiscussionDiffBlock(diffBlock, mock(ChangeRequestLineDiffReference.class));
+        assertNotEquals(block, otherReference);
+
+        UnifiedDiffBlock<String, Character> otherDiffBlock = new UnifiedDiffBlock<>();
+        otherDiffBlock.add(null);
+        ChangeRequestDiscussionDiffBlock otherDiffBlockValue =
+            new ChangeRequestDiscussionDiffBlock(otherDiffBlock, reference);
+        assertNotEquals(block, otherDiffBlockValue);
+    }
+}

--- a/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/ChangeRequestDiscussionEventTest.java
+++ b/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/ChangeRequestDiscussionEventTest.java
@@ -1,0 +1,41 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.changerequest.discussions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ChangeRequestDiscussionEvent}.
+ *
+ * @version $Id$
+ */
+class ChangeRequestDiscussionEventTest
+{
+    @Test
+    void matches()
+    {
+        ChangeRequestDiscussionEvent event = new ChangeRequestDiscussionEvent();
+        assertTrue(event.matches(new ChangeRequestDiscussionEvent()));
+        assertFalse(event.matches("somethingelse"));
+    }
+}

--- a/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/internal/DefaultChangeRequestDiscussionStoreConfigurationTest.java
+++ b/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/internal/DefaultChangeRequestDiscussionStoreConfigurationTest.java
@@ -1,0 +1,147 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.changerequest.discussions.internal;
+
+import java.util.Optional;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.xwiki.contrib.changerequest.ChangeRequest;
+import org.xwiki.contrib.changerequest.ChangeRequestException;
+import org.xwiki.contrib.changerequest.storage.ChangeRequestStorageManager;
+import org.xwiki.contrib.discussions.DiscussionStoreConfigurationParameters;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWikiContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DefaultChangeRequestDiscussionStoreConfiguration}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class DefaultChangeRequestDiscussionStoreConfigurationTest
+{
+    private static final String PARAM_KEY =
+        DefaultChangeRequestDiscussionStoreConfiguration.CHANGE_REQUEST_ID_PARAMETER_KEY;
+
+    @InjectMockComponents
+    private DefaultChangeRequestDiscussionStoreConfiguration configuration;
+
+    @MockComponent
+    private DocumentReferenceResolver<ChangeRequest> changeRequestDocumentReferenceResolver;
+
+    @MockComponent
+    private ChangeRequestStorageManager changeRequestStorageManager;
+
+    @MockComponent
+    private Provider<XWikiContext> contextProvider;
+
+    @RegisterExtension
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
+
+    @Test
+    void getDiscussionContextSpaceStorageLocationWhenStringParameter() throws ChangeRequestException
+    {
+        DiscussionStoreConfigurationParameters parameters = new DiscussionStoreConfigurationParameters();
+        parameters.put(PARAM_KEY, "CRID");
+
+        ChangeRequest changeRequest = mock(ChangeRequest.class);
+        when(this.changeRequestStorageManager.load("CRID")).thenReturn(Optional.of(changeRequest));
+        DocumentReference documentReference = new DocumentReference("wiki", "ChangeRequestSpace", "WebHome");
+        when(this.changeRequestDocumentReferenceResolver.resolve(changeRequest)).thenReturn(documentReference);
+
+        SpaceReference result = this.configuration.getDiscussionContextSpaceStorageLocation(parameters, null);
+
+        assertEquals(new SpaceReference("DiscussionContext",
+            new SpaceReference("Discussions", documentReference.getLastSpaceReference())), result);
+    }
+
+    @Test
+    void getDiscussionSpaceStorageLocationWhenArrayParameter() throws ChangeRequestException
+    {
+        DiscussionStoreConfigurationParameters parameters = new DiscussionStoreConfigurationParameters();
+        parameters.put(PARAM_KEY, new String[] { "CRID" });
+
+        ChangeRequest changeRequest = mock(ChangeRequest.class);
+        when(this.changeRequestStorageManager.load("CRID")).thenReturn(Optional.of(changeRequest));
+        DocumentReference documentReference = new DocumentReference("wiki", "ChangeRequestSpace", "WebHome");
+        when(this.changeRequestDocumentReferenceResolver.resolve(changeRequest)).thenReturn(documentReference);
+
+        SpaceReference result = this.configuration.getDiscussionSpaceStorageLocation(parameters);
+
+        assertEquals(new SpaceReference("Discussion",
+            new SpaceReference("Discussions", documentReference.getLastSpaceReference())), result);
+    }
+
+    @Test
+    void getMessageSpaceStorageLocationWhenMissingParameterFallsBackToContextWiki()
+    {
+        DiscussionStoreConfigurationParameters parameters = new DiscussionStoreConfigurationParameters();
+
+        XWikiContext context = mock(XWikiContext.class);
+        when(this.contextProvider.get()).thenReturn(context);
+        WikiReference wikiReference = new WikiReference("wiki");
+        when(context.getWikiReference()).thenReturn(wikiReference);
+
+        SpaceReference result = this.configuration.getMessageSpaceStorageLocation(parameters, null);
+
+        assertEquals(new SpaceReference("Message",
+            new SpaceReference("Discussions", new SpaceReference("ChangeRequest", wikiReference))), result);
+        assertEquals(1, this.logCapture.size());
+        assertEquals("Missing or wrong parameter for change request id: [null]", this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void getDiscussionContextSpaceStorageLocationWhenLoadFailsFallsBackToContextWiki() throws ChangeRequestException
+    {
+        DiscussionStoreConfigurationParameters parameters = new DiscussionStoreConfigurationParameters();
+        parameters.put(PARAM_KEY, "CRID");
+
+        when(this.changeRequestStorageManager.load("CRID")).thenThrow(new ChangeRequestException("error"));
+
+        XWikiContext context = mock(XWikiContext.class);
+        when(this.contextProvider.get()).thenReturn(context);
+        WikiReference wikiReference = new WikiReference("wiki");
+        when(context.getWikiReference()).thenReturn(wikiReference);
+
+        SpaceReference result = this.configuration.getDiscussionContextSpaceStorageLocation(parameters, null);
+
+        assertEquals(new SpaceReference("DiscussionContext",
+            new SpaceReference("Discussions", new SpaceReference("ChangeRequest", wikiReference))), result);
+        assertEquals(1, this.logCapture.size());
+        assertEquals("Error while getting value for change request id from [CRID]: "
+            + "[ChangeRequestException: error]", this.logCapture.getMessage(0));
+    }
+}

--- a/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/internal/FileChangeReferenceRenamedListenerTest.java
+++ b/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/internal/FileChangeReferenceRenamedListenerTest.java
@@ -1,0 +1,113 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.changerequest.discussions.internal;
+
+import java.util.Locale;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.xwiki.contrib.changerequest.discussions.ChangeRequestDiscussionException;
+import org.xwiki.contrib.changerequest.discussions.ChangeRequestDiscussionService;
+import org.xwiki.contrib.changerequest.events.FileChangeReferenceRenamedEvent;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.observation.remote.RemoteObservationManagerContext;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link FileChangeReferenceRenamedListener}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class FileChangeReferenceRenamedListenerTest
+{
+    @InjectMockComponents
+    private FileChangeReferenceRenamedListener listener;
+
+    @MockComponent
+    private Provider<ChangeRequestDiscussionService> discussionServiceProvider;
+
+    @MockComponent
+    private RemoteObservationManagerContext remoteObservationManagerContext;
+
+    @RegisterExtension
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.ERROR);
+
+    @Test
+    void onEventWhenRemoteStateDoesNothing()
+    {
+        when(this.remoteObservationManagerContext.isRemoteState()).thenReturn(true);
+        this.listener.onEvent(new FileChangeReferenceRenamedEvent(), "CRID", null);
+        verifyNoInteractions(this.discussionServiceProvider);
+    }
+
+    @Test
+    void onEventRefactorsDiscussionFileReference() throws ChangeRequestDiscussionException
+    {
+        when(this.remoteObservationManagerContext.isRemoteState()).thenReturn(false);
+        ChangeRequestDiscussionService discussionService = mock(ChangeRequestDiscussionService.class);
+        when(this.discussionServiceProvider.get()).thenReturn(discussionService);
+
+        DocumentReference source = new DocumentReference("wiki", "Space", "Source");
+        DocumentReference target = new DocumentReference("wiki", "Space", "Target", Locale.ROOT);
+        FileChangeReferenceRenamedEvent event = new FileChangeReferenceRenamedEvent(source, target, true);
+
+        this.listener.onEvent(event, "CRID", null);
+
+        DocumentReference expectedTarget = new DocumentReference(target, (Locale) null);
+        verify(discussionService).refactorDiscussionFileReference("CRID", source, expectedTarget, true);
+    }
+
+    @Test
+    void onEventWhenExceptionDoesNotThrow() throws ChangeRequestDiscussionException
+    {
+        when(this.remoteObservationManagerContext.isRemoteState()).thenReturn(false);
+        ChangeRequestDiscussionService discussionService = mock(ChangeRequestDiscussionService.class);
+        when(this.discussionServiceProvider.get()).thenReturn(discussionService);
+
+        DocumentReference source = new DocumentReference("wiki", "Space", "Source");
+        DocumentReference target = new DocumentReference("wiki", "Space", "Target");
+        FileChangeReferenceRenamedEvent event = new FileChangeReferenceRenamedEvent(source, target, false);
+
+        doThrow(new ChangeRequestDiscussionException("error"))
+            .when(discussionService).refactorDiscussionFileReference(eq("CRID"), eq(source), eq(target), eq(false));
+
+        this.listener.onEvent(event, "CRID", null);
+
+        verify(discussionService).refactorDiscussionFileReference("CRID", source, target, false);
+        assertEquals(1, this.logCapture.size());
+        assertEquals("Error while trying to refactor discussions of change request [CRID] for the move from "
+            + "[wiki:Space.Source] to [wiki:Space.Target] (isDeep: [false])", this.logCapture.getMessage(0));
+    }
+}

--- a/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/internal/MessageEventListenerTest.java
+++ b/application-changerequest-discussions/src/test/java/org/xwiki/contrib/changerequest/discussions/internal/MessageEventListenerTest.java
@@ -1,0 +1,190 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.changerequest.discussions.internal;
+
+import java.util.Optional;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.xwiki.contrib.changerequest.ChangeRequest;
+import org.xwiki.contrib.changerequest.ChangeRequestException;
+import org.xwiki.contrib.changerequest.discussions.ChangeRequestDiscussionException;
+import org.xwiki.contrib.changerequest.discussions.ChangeRequestDiscussionService;
+import org.xwiki.contrib.changerequest.discussions.references.AbstractChangeRequestDiscussionContextReference;
+import org.xwiki.contrib.changerequest.storage.ChangeRequestStorageManager;
+import org.xwiki.contrib.discussions.domain.Discussion;
+import org.xwiki.contrib.discussions.domain.Message;
+import org.xwiki.contrib.discussions.events.MessageEvent;
+import org.xwiki.localization.ContextualLocalizationManager;
+import org.xwiki.observation.remote.RemoteObservationManagerContext;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link MessageEventListener}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class MessageEventListenerTest
+{
+    private static final String APPLICATION_HINT = ChangeRequestDiscussionService.APPLICATION_HINT;
+
+    @InjectMockComponents
+    private MessageEventListener listener;
+
+    @MockComponent
+    private Provider<ChangeRequestDiscussionService> discussionServiceProvider;
+
+    @MockComponent
+    private Provider<ChangeRequestStorageManager> changeRequestStorageManagerProvider;
+
+    @MockComponent
+    private Provider<ContextualLocalizationManager> contextualLocalizationManagerProvider;
+
+    @MockComponent
+    private RemoteObservationManagerContext remoteObservationManagerContext;
+
+    @RegisterExtension
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
+
+    @Test
+    void onEventWhenWrongApplicationHintDoesNothing()
+    {
+        Message message = mock(Message.class);
+        this.listener.onEvent(mock(MessageEvent.class), "somethingelse", message);
+        verifyNoInteractions(this.discussionServiceProvider);
+        verifyNoInteractions(this.changeRequestStorageManagerProvider);
+    }
+
+    @Test
+    void onEventSavesChangeRequestWhenFound() throws ChangeRequestDiscussionException, ChangeRequestException
+    {
+        Message message = mock(Message.class);
+        Discussion discussion = mock(Discussion.class);
+        when(message.getDiscussion()).thenReturn(discussion);
+
+        ChangeRequestDiscussionService discussionService = mock(ChangeRequestDiscussionService.class);
+        when(this.discussionServiceProvider.get()).thenReturn(discussionService);
+        AbstractChangeRequestDiscussionContextReference reference =
+            mock(AbstractChangeRequestDiscussionContextReference.class);
+        when(discussionService.getReferenceFrom(discussion)).thenReturn(reference);
+        when(reference.getChangeRequestId()).thenReturn("CRID");
+
+        ChangeRequestStorageManager storageManager = mock(ChangeRequestStorageManager.class);
+        when(this.changeRequestStorageManagerProvider.get()).thenReturn(storageManager);
+        ChangeRequest changeRequest = mock(ChangeRequest.class);
+        when(storageManager.load("CRID")).thenReturn(Optional.of(changeRequest));
+
+        ContextualLocalizationManager localizationManager = mock(ContextualLocalizationManager.class);
+        when(this.contextualLocalizationManagerProvider.get()).thenReturn(localizationManager);
+        when(localizationManager.getTranslationPlain("changerequest.save.messagecreated")).thenReturn("save comment");
+
+        this.listener.onEvent(mock(MessageEvent.class), APPLICATION_HINT, message);
+
+        verify(changeRequest).updateDate();
+        verify(storageManager).save(changeRequest, "save comment");
+    }
+
+    @Test
+    void onEventWhenChangeRequestNotFoundLogsWarning() throws ChangeRequestDiscussionException,
+        ChangeRequestException
+    {
+        Message message = mock(Message.class);
+        Discussion discussion = mock(Discussion.class);
+        when(message.getDiscussion()).thenReturn(discussion);
+
+        ChangeRequestDiscussionService discussionService = mock(ChangeRequestDiscussionService.class);
+        when(this.discussionServiceProvider.get()).thenReturn(discussionService);
+        AbstractChangeRequestDiscussionContextReference reference =
+            mock(AbstractChangeRequestDiscussionContextReference.class);
+        when(discussionService.getReferenceFrom(discussion)).thenReturn(reference);
+        when(reference.getChangeRequestId()).thenReturn("CRID");
+
+        ChangeRequestStorageManager storageManager = mock(ChangeRequestStorageManager.class);
+        when(this.changeRequestStorageManagerProvider.get()).thenReturn(storageManager);
+        when(storageManager.load("CRID")).thenReturn(Optional.empty());
+
+        this.listener.onEvent(mock(MessageEvent.class), APPLICATION_HINT, message);
+
+        verify(storageManager, never()).save(any(), any());
+        assertEquals(1, this.logCapture.size());
+        assertEquals("No change request found with id [CRID]", this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void onEventWhenDiscussionExceptionDoesNotThrow() throws ChangeRequestDiscussionException
+    {
+        Message message = mock(Message.class);
+        Discussion discussion = mock(Discussion.class);
+        when(message.getDiscussion()).thenReturn(discussion);
+
+        ChangeRequestDiscussionService discussionService = mock(ChangeRequestDiscussionService.class);
+        when(this.discussionServiceProvider.get()).thenReturn(discussionService);
+        when(discussionService.getReferenceFrom(discussion))
+            .thenThrow(new ChangeRequestDiscussionException("error"));
+
+        this.listener.onEvent(mock(MessageEvent.class), APPLICATION_HINT, message);
+
+        verifyNoInteractions(this.changeRequestStorageManagerProvider);
+        assertEquals(1, this.logCapture.size());
+        assertEquals("Error when trying to get reference from discussion [" + discussion + "]",
+            this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void onEventWhenChangeRequestExceptionDoesNotThrow() throws ChangeRequestDiscussionException,
+        ChangeRequestException
+    {
+        Message message = mock(Message.class);
+        Discussion discussion = mock(Discussion.class);
+        when(message.getDiscussion()).thenReturn(discussion);
+
+        ChangeRequestDiscussionService discussionService = mock(ChangeRequestDiscussionService.class);
+        when(this.discussionServiceProvider.get()).thenReturn(discussionService);
+        AbstractChangeRequestDiscussionContextReference reference =
+            mock(AbstractChangeRequestDiscussionContextReference.class);
+        when(discussionService.getReferenceFrom(discussion)).thenReturn(reference);
+        when(reference.getChangeRequestId()).thenReturn("CRID");
+
+        ChangeRequestStorageManager storageManager = mock(ChangeRequestStorageManager.class);
+        when(this.changeRequestStorageManagerProvider.get()).thenReturn(storageManager);
+        when(storageManager.load("CRID")).thenThrow(new ChangeRequestException("error"));
+
+        this.listener.onEvent(mock(MessageEvent.class), APPLICATION_HINT, message);
+
+        verify(storageManager, never()).save(any(), any());
+        assertEquals(1, this.logCapture.size());
+        assertEquals("Error when trying to load or save change request [CRID]", this.logCapture.getMessage(0));
+    }
+}


### PR DESCRIPTION
## Description

Adds unit tests for the `application-changerequest-discussions` module for classes that had 0% or low test coverage, prioritizing the most recently changed/added code:

- `FileChangeReferenceRenamedListener` (added by the CRAPP-168 refactor-on-move/rename change): remote-state skip, successful refactor with reference denormalization, and exception handling.
- `MessageEventListener`: application-hint filtering, save-on-found, warn-on-not-found, and both exception paths (`ChangeRequestDiscussionException` / `ChangeRequestException`).
- `DefaultChangeRequestDiscussionStoreConfiguration`: `String`/`String[]` change request id parameter forms, missing/wrong parameter fallback, and load-failure fallback.
- `ChangeRequestDiscussionDiffBlock` and `ChangeRequestDiscussionEvent`: getters, `equals`/`hashCode`, and `matches`.

As a result, the module's overall JaCoCo instruction coverage went from ~74% to ~84%, so `xwiki.jacoco.instructionRatio` was raised from `0.74` to `0.83` in the module `pom.xml`.

## Clarifications

No behavior change, tests only (plus the coverage threshold bump).

## Executed Tests

- `xmvn clean install -B -ntp -Pquality` (full quality build, including the raised JaCoCo gate) — green.

## Expected merging strategy

Prefers squash: Yes