### PR TITLE
[Misc] Avoid recomputing merges already resolved when checking file change conflicts

### DIFF
--- a/application-changerequest-default/src/main/java/org/xwiki/contrib/changerequest/internal/DefaultChangeRequestMergeManager.java
+++ b/application-changerequest-default/src/main/java/org/xwiki/contrib/changerequest/internal/DefaultChangeRequestMergeManager.java
@@ -119,31 +119,7 @@ public class DefaultChangeRequestMergeManager implements ChangeRequestMergeManag
     @Override
     public boolean hasConflict(FileChange fileChange) throws ChangeRequestException
     {
-        boolean result;
-        Optional<Boolean> optional = this.mergeCacheManager.hasConflict(fileChange);
-        if (optional.isPresent()) {
-            result = optional.get();
-        } else {
-            switch (fileChange.getType()) {
-                case DELETION:
-                    result = deletionHasConflict(fileChange);
-                    break;
-
-                case CREATION:
-                    result = creationHasConflict(fileChange);
-                    break;
-
-                case EDITION:
-                    result = editionHasConflict(fileChange);
-                    break;
-
-                default:
-                case NO_CHANGE:
-                    result = false;
-            }
-            this.mergeCacheManager.setConflictStatus(fileChange, result);
-        }
-        return result;
+        return getMergeDocumentResult(fileChange).hasConflicts();
     }
 
     private boolean creationHasConflict(FileChange fileChange) throws ChangeRequestException
@@ -164,35 +140,6 @@ public class DefaultChangeRequestMergeManager implements ChangeRequestMergeManag
         //   - case 3: the page has been already deleted, the CR request for deletion with a previous version:
         //             the CR can be refreshed, and when doing so the CR shows no change for this file
         return false;
-    }
-
-    private boolean editionHasConflict(FileChange fileChange) throws ChangeRequestException
-    {
-        DocumentModelBridge modifiedDoc =
-            this.fileChangeStorageManager.getModifiedDocumentFromFileChange(fileChange);
-        DocumentModelBridge originalDoc =
-            this.fileChangeStorageManager.getCurrentDocumentFromFileChange(fileChange);
-
-        DocumentModelBridge previousDoc;
-        Optional<DocumentModelBridge> optionalPreviousDoc =
-            this.fileChangeStorageManager.getPreviousDocumentFromFileChange(fileChange);
-        if (!optionalPreviousDoc.isEmpty()) {
-            previousDoc = optionalPreviousDoc.get();
-            XWikiContext context = this.contextProvider.get();
-            MergeConfiguration mergeConfiguration = new MergeConfiguration();
-
-            // We need the reference of the user and the document in the config to retrieve
-            // the conflict decision in the MergeManager.
-            mergeConfiguration.setUserReference(context.getUserReference());
-            mergeConfiguration.setConcernedDocument(modifiedDoc.getDocumentReference());
-            mergeConfiguration.setProvidedVersionsModifiables(false);
-
-            MergeDocumentResult mergeDocumentResult =
-                mergeManager.mergeDocument(previousDoc, originalDoc, modifiedDoc, mergeConfiguration);
-            return mergeDocumentResult.hasConflicts();
-        } else {
-            return true;
-        }
     }
 
     @Override

--- a/application-changerequest-default/src/main/java/org/xwiki/contrib/changerequest/internal/cache/MergeCacheManager.java
+++ b/application-changerequest-default/src/main/java/org/xwiki/contrib/changerequest/internal/cache/MergeCacheManager.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.xwiki.cache.Cache;
 import org.xwiki.cache.CacheException;
 import org.xwiki.cache.CacheManager;
@@ -61,35 +60,9 @@ public class MergeCacheManager implements Initializable, Disposable
     @Inject
     private EntityReferenceSerializer<String> entityReferenceSerializer;
 
-    private Cache<Pair<DocumentReference, Boolean>> hasConflictCache;
     private Cache<ChangeRequestMergeDocumentResult> crMergeDocumentResultCache;
 
     private final Map<DocumentReference, Set<String>> cacheKeysMap = new ConcurrentHashMap<>();
-
-    private final class ConflictCacheEntryListener implements CacheEntryListener<Pair<DocumentReference, Boolean>>
-    {
-        @Override
-        public void cacheEntryAdded(CacheEntryEvent<Pair<DocumentReference, Boolean>> event)
-        {
-            DocumentReference documentReference = event.getEntry().getValue().getLeft();
-            String key = event.getEntry().getKey();
-            MergeCacheManager.this.addCacheEntry(documentReference, key);
-        }
-
-        @Override
-        public void cacheEntryRemoved(CacheEntryEvent<Pair<DocumentReference, Boolean>> event)
-        {
-            DocumentReference documentReference = event.getEntry().getValue().getLeft();
-            String key = event.getEntry().getKey();
-            MergeCacheManager.this.removeCacheEntry(documentReference, key);
-        }
-
-        @Override
-        public void cacheEntryModified(CacheEntryEvent<Pair<DocumentReference, Boolean>> event)
-        {
-            // Nothing to do.
-        }
-    }
 
     private final class CRMergeDocumentResultCacheEntryListener
         implements CacheEntryListener<ChangeRequestMergeDocumentResult>
@@ -144,9 +117,6 @@ public class MergeCacheManager implements Initializable, Disposable
     public void initialize() throws InitializationException
     {
         try {
-            this.hasConflictCache =
-                this.cacheManager.createNewCache(new LRUCacheConfiguration("changerequest.hasConflictCache", 1000));
-            this.hasConflictCache.addCacheEntryListener(new ConflictCacheEntryListener());
             this.crMergeDocumentResultCache =
                 this.cacheManager.createNewCache(new LRUCacheConfiguration("changerequest.crMergeDocumentResult", 100));
             this.crMergeDocumentResultCache.addCacheEntryListener(new CRMergeDocumentResultCacheEntryListener());
@@ -158,41 +128,12 @@ public class MergeCacheManager implements Initializable, Disposable
     @Override
     public void dispose() throws ComponentLifecycleException
     {
-        this.hasConflictCache.dispose();
         this.crMergeDocumentResultCache.dispose();
     }
 
     private String getCacheKey(FileChange fileChange)
     {
         return String.format("%s-%s", fileChange.getId(), fileChange.getChangeRequest().getId());
-    }
-
-    /**
-     * Look in the cache if there is a conflict value for the given filechange.
-     *
-     * @param fileChange the filechange for which to check if there's a conflict.
-     * @return {@link Optional#empty()} if there's no value in cache, else an optional containing the boolean result.
-     */
-    public Optional<Boolean> hasConflict(FileChange fileChange)
-    {
-        Pair<DocumentReference, Boolean> pair =
-            this.hasConflictCache.get(this.getCacheKey(fileChange));
-        if (pair != null) {
-            return Optional.of(pair.getRight());
-        } else {
-            return Optional.empty();
-        }
-    }
-
-    /**
-     * Put in cache the conflict value of the given filechange.
-     *
-     * @param fileChange the filechange for which to put in cache the conflict value.
-     * @param status the conflict value of the given filechange.
-     */
-    public void setConflictStatus(FileChange fileChange, boolean status)
-    {
-        this.hasConflictCache.set(getCacheKey(fileChange), Pair.of(fileChange.getTargetEntity(), status));
     }
 
     /**
@@ -235,7 +176,6 @@ public class MergeCacheManager implements Initializable, Disposable
     {
         if (this.cacheKeysMap.containsKey(documentReference)) {
             for (String key : new HashSet<>(this.cacheKeysMap.get(documentReference))) {
-                this.hasConflictCache.remove(key);
                 this.crMergeDocumentResultCache.remove(key);
             }
         }
@@ -248,7 +188,6 @@ public class MergeCacheManager implements Initializable, Disposable
      */
     public void invalidate(FileChange fileChange)
     {
-        this.hasConflictCache.remove(getCacheKey(fileChange));
         this.crMergeDocumentResultCache.remove(getCacheKey(fileChange));
     }
 
@@ -258,6 +197,5 @@ public class MergeCacheManager implements Initializable, Disposable
     public void invalidateAll()
     {
         this.crMergeDocumentResultCache.removeAll();
-        this.hasConflictCache.removeAll();
     }
 }

--- a/application-changerequest-default/src/test/java/org/xwiki/contrib/changerequest/internal/DefaultChangeRequestMergeManagerTest.java
+++ b/application-changerequest-default/src/test/java/org/xwiki/contrib/changerequest/internal/DefaultChangeRequestMergeManagerTest.java
@@ -26,7 +26,6 @@ import javax.inject.Provider;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xwiki.bridge.DocumentModelBridge;
 import org.xwiki.contrib.changerequest.ChangeRequest;
 import org.xwiki.contrib.changerequest.ChangeRequestException;
 import org.xwiki.contrib.changerequest.ChangeRequestManager;
@@ -122,43 +121,17 @@ class DefaultChangeRequestMergeManagerTest
     void hasConflictWithEdition() throws ChangeRequestException
     {
         FileChange fileChange = mock(FileChange.class);
-        when(this.mergeCacheManager.hasConflict(fileChange)).thenReturn(Optional.of(false));
+        ChangeRequestMergeDocumentResult mergeDocumentResult = mock(ChangeRequestMergeDocumentResult.class);
+        when(this.mergeCacheManager.getChangeRequestMergeDocumentResult(fileChange))
+            .thenReturn(Optional.of(mergeDocumentResult));
+
+        when(mergeDocumentResult.hasConflicts()).thenReturn(false);
         assertFalse(this.crMergeManager.hasConflict(fileChange));
-        verifyNoInteractions(this.mergeManager);
-
-        when(this.mergeCacheManager.hasConflict(fileChange)).thenReturn(Optional.empty());
-        when(fileChange.getType()).thenReturn(FileChange.FileChangeType.EDITION);
-        DocumentModelBridge modifiedDoc = mock(DocumentModelBridge.class);
-        DocumentModelBridge currentDoc = mock(DocumentModelBridge.class);
-        DocumentModelBridge previousDoc = mock(DocumentModelBridge.class);
-
-        when(this.fileChangeStorageManager.getModifiedDocumentFromFileChange(fileChange)).thenReturn(modifiedDoc);
-        when(this.fileChangeStorageManager.getCurrentDocumentFromFileChange(fileChange)).thenReturn(currentDoc);
-        when(this.fileChangeStorageManager.getPreviousDocumentFromFileChange(fileChange))
-            .thenReturn(Optional.of(previousDoc));
-
-        DocumentReference userDocReference = mock(DocumentReference.class);
-        when(context.getUserReference()).thenReturn(userDocReference);
-
-        DocumentReference modifiedDocReference = mock(DocumentReference.class);
-        when(modifiedDoc.getDocumentReference()).thenReturn(modifiedDocReference);
-
-        MergeDocumentResult mergeDocumentResult = mock(MergeDocumentResult.class);
-        when(this.mergeManager
-            .mergeDocument(eq(previousDoc), eq(currentDoc), eq(modifiedDoc), any(MergeConfiguration.class)))
-            .thenAnswer(invocationOnMock -> {
-                MergeConfiguration mergeConfiguration = invocationOnMock.getArgument(3);
-                assertEquals(modifiedDocReference, mergeConfiguration.getConcernedDocument());
-                assertEquals(userDocReference, mergeConfiguration.getUserReference());
-                assertFalse(mergeConfiguration.isProvidedVersionsModifiables());
-                return mergeDocumentResult;
-            });
 
         when(mergeDocumentResult.hasConflicts()).thenReturn(true);
         assertTrue(this.crMergeManager.hasConflict(fileChange));
-        verify(this.mergeManager)
-            .mergeDocument(eq(previousDoc), eq(currentDoc), eq(modifiedDoc), any(MergeConfiguration.class));
-        verify(this.mergeCacheManager).setConflictStatus(fileChange, true);
+
+        verifyNoInteractions(this.mergeManager);
     }
 
     @Test


### PR DESCRIPTION
## Jira URL

N/A ([Misc] change, no dedicated issue)

## Changes

### Description

`hasConflict(FileChange)` in `DefaultChangeRequestMergeManager` re-ran an independent 3-way merge (`editionHasConflict`) to determine whether a file change conflicts, even though `getMergeDocumentResult(FileChange)` already computes the exact same conflict status and exposes it via `ChangeRequestMergeDocumentResult#hasConflicts()`.

When viewing a change request, the UI computes `getMergeDocumentResult` for every modified file (to render diffs) and then separately calls `hasConflict(ChangeRequest)` (which loops `hasConflict(FileChange)`) for the "checks" tab. For a conflicting `EDITION` file change this meant the same document merge was performed multiple times per page view.

This PR makes `hasConflict(FileChange)` simply delegate to `getMergeDocumentResult(fileChange).hasConflicts()`, reusing the already-cached result instead of recomputing it.

### Clarifications

- `editionHasConflict` is now dead code and has been removed. `deletionHasConflict`/`creationHasConflict` are kept since `getMergeDocumentResult` still calls them directly.
- The now-unused `hasConflictCache` (a separate 1000-entry LRU cache) and its associated listener/bookkeeping in `MergeCacheManager` have been removed, since conflict status is now served from the existing `crMergeDocumentResultCache`.
- No public API signature changes; `ChangeRequestMergeManager#hasConflict(FileChange)` and `#hasConflict(ChangeRequest)` behave identically, just cheaper on a cache miss.

## Screenshots & Video

N/A (internal performance change, no UI/behavior difference).

## Executed Tests

- `xmvn -B -ntp -pl application-changerequest-default -am test` — 210 tests, all passing.
- `xmvn -B -ntp -pl application-changerequest-default -am verify -DskipTests` — checkstyle, license headers, Revapi (no API break), Spoon: all clean.

## Expected merging strategy

Prefers squash: Yes

---
Generated with [Claude Code](https://claude.com/claude-code)